### PR TITLE
Remove page-based pagination, cursor-only for all list endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,32 +44,5 @@ private_key = b"-----BEGIN PRIVATE KEY-----\n....-----END PRIVATE KEY-----\n"
 api_client = APIClient(api_key, api_url, private_key=private_key)
 ```
 
-### Cursor Pagination
-All list endpoints use cursor-based pagination. Pass `cursor` to iterate through results.
-
-```python
-# Fetch first page
-response = api_client.get_transactions(limit=20)
-print(response.results)
-
-# Fetch next page using the cursor from the previous response
-if response.has_next:
-    next_response = api_client.get_transactions(limit=20, cursor=response.next_cursor)
-    print(next_response.results)
-
-# Iterate through all pages
-cursor = None
-all_items = []
-while True:
-    response = api_client.get_vaults(limit=50, cursor=cursor)
-    all_items.extend(response.results)
-    if not response.has_next:
-        break
-    cursor = response.next_cursor
-
-# With filters
-response = api_client.get_contacts(params={"blockChain": "ETHEREUM"}, limit=10)
-```
-
 ### Code Examples
 [Here](https://github.com/horcrux01/primevault_api_sdk_public/tree/main/examples)

--- a/README.md
+++ b/README.md
@@ -44,5 +44,32 @@ private_key = b"-----BEGIN PRIVATE KEY-----\n....-----END PRIVATE KEY-----\n"
 api_client = APIClient(api_key, api_url, private_key=private_key)
 ```
 
+### Cursor Pagination
+All list endpoints use cursor-based pagination. Pass `cursor` to iterate through results.
+
+```python
+# Fetch first page
+response = api_client.get_transactions(limit=20)
+print(response.results)
+
+# Fetch next page using the cursor from the previous response
+if response.has_next:
+    next_response = api_client.get_transactions(limit=20, cursor=response.next_cursor)
+    print(next_response.results)
+
+# Iterate through all pages
+cursor = None
+all_items = []
+while True:
+    response = api_client.get_vaults(limit=50, cursor=cursor)
+    all_items.extend(response.results)
+    if not response.has_next:
+        break
+    cursor = response.next_cursor
+
+# With filters
+response = api_client.get_contacts(params={"blockChain": "ETHEREUM"}, limit=10)
+```
+
 ### Code Examples
 [Here](https://github.com/horcrux01/primevault_api_sdk_public/tree/main/examples)

--- a/examples/bank_account.py
+++ b/examples/bank_account.py
@@ -52,12 +52,25 @@ def decline_bank_account(api_client: APIClient, bank_account_id: str):
 
 def list_bank_accounts(api_client: APIClient):
     """List all bank accounts with cursor-based pagination."""
-    response = api_client.get_bank_accounts(params={"status": "APPROVED"}, limit=20)
-    for account in response.results:
-        print(
-            f"  - {account.accountName} ({account.paymentMethod}) bankName={account.bankName}"
+    all_accounts = []
+    cursor = None
+
+    while True:
+        response = api_client.get_bank_accounts(
+            params={"status": "APPROVED"}, limit=20, cursor=cursor
         )
-    return response
+        all_accounts.extend(response.results)
+        for account in response.results:
+            print(
+                f"  - {account.accountName} ({account.paymentMethod}) bankName={account.bankName}"
+            )
+
+        if not response.has_next or not response.next_cursor:
+            break
+        cursor = response.next_cursor
+
+    print(f"Total bank accounts: {len(all_accounts)}")
+    return all_accounts
 
 
 def get_bank_account(api_client: APIClient, bank_account_id: str):

--- a/examples/bank_account.py
+++ b/examples/bank_account.py
@@ -65,9 +65,9 @@ def list_bank_accounts(api_client: APIClient):
                 f"  - {account.accountName} ({account.paymentMethod}) bankName={account.bankName}"
             )
 
-        if not response.has_next or not response.next_cursor:
+        if not response.hasNext or not response.nextCursor:
             break
-        cursor = response.next_cursor
+        cursor = response.nextCursor
 
     print(f"Total bank accounts: {len(all_accounts)}")
     return all_accounts

--- a/examples/bank_account.py
+++ b/examples/bank_account.py
@@ -24,7 +24,9 @@ def create_and_approve_bank_account(api_client: APIClient):
 
     bank_account = api_client.create_bank_account(request)
     print(f"Created: {bank_account.id} status={bank_account.status}")
-    print(f"  accountName={bank_account.accountName} bankName={bank_account.bankName} city={bank_account.city}")
+    print(
+        f"  accountName={bank_account.accountName} bankName={bank_account.bankName} city={bank_account.city}"
+    )
 
     approve_response = api_client.submit_bank_account_approval_action(
         GetApprovalRequest(
@@ -49,13 +51,12 @@ def decline_bank_account(api_client: APIClient, bank_account_id: str):
 
 
 def list_bank_accounts(api_client: APIClient):
-    """List all bank accounts with pagination."""
-    response = api_client.get_bank_accounts(
-        params={"status": "APPROVED"}, page=1, limit=20
-    )
-    print(f"Found {response.count} approved bank accounts")
+    """List all bank accounts with cursor-based pagination."""
+    response = api_client.get_bank_accounts(params={"status": "APPROVED"}, limit=20)
     for account in response.results:
-        print(f"  - {account.accountName} ({account.paymentMethod}) bankName={account.bankName}")
+        print(
+            f"  - {account.accountName} ({account.paymentMethod}) bankName={account.bankName}"
+        )
     return response
 
 

--- a/examples/contact.py
+++ b/examples/contact.py
@@ -26,13 +26,13 @@ def create_and_approve_contact(api_client: APIClient):
         )
     )
     print(f"Contact created: {contact.id} ({contact.status})")
-    print(f"  name={contact.name}, chain={contact.blockChain}, assetList={contact.assetList}")
+    print(
+        f"  name={contact.name}, chain={contact.blockChain}, assetList={contact.assetList}"
+    )
 
     # Step 2: Approve the contact using its ID as the entityId
     approval = api_client.initiate_change_approval_action(
-        GetApprovalRequest(
-            entityId=contact.id, action=ApprovalAction.APPROVE.value
-        )
+        GetApprovalRequest(entityId=contact.id, action=ApprovalAction.APPROVE.value)
     )
     print(f"Approval result: success={approval.success}")
 
@@ -46,10 +46,33 @@ def create_and_approve_contact(api_client: APIClient):
 def decline_contact(api_client: APIClient, contact_id: str):
     """Decline a pending contact change request."""
     return api_client.initiate_change_approval_action(
-        GetApprovalRequest(
-            entityId=contact_id, action=ApprovalAction.REJECT.value
-        )
+        GetApprovalRequest(entityId=contact_id, action=ApprovalAction.REJECT.value)
     )
+
+
+def get_contacts(api_client: APIClient):
+    """List all contacts with cursor-based pagination."""
+    all_contacts = []
+    cursor = None
+
+    while True:
+        response = api_client.get_contacts(limit=50, cursor=cursor)
+        all_contacts.extend(response.results)
+        print(f"Fetched {len(response.results)} contacts (total: {len(all_contacts)})")
+
+        if not response.has_next or not response.next_cursor:
+            break
+        cursor = response.next_cursor
+
+    print(f"Total contacts: {len(all_contacts)}")
+    return all_contacts
+
+
+def get_contacts_filtered(api_client: APIClient):
+    """List contacts with a filter."""
+    response = api_client.get_contacts(params={"blockChain": "ETHEREUM"}, limit=10)
+    for contact in response.results:
+        print(f"  {contact.id} — {contact.name} ({contact.blockChain})")
 
 
 def update_contact_asset_list(
@@ -69,9 +92,7 @@ def update_contact_asset_list(
 
     # Step 2: Approve the update
     approval = api_client.initiate_change_approval_action(
-        GetApprovalRequest(
-            entityId=updated.id, action=ApprovalAction.APPROVE.value
-        )
+        GetApprovalRequest(entityId=updated.id, action=ApprovalAction.APPROVE.value)
     )
     print(f"Update approval result: success={approval.success}")
 

--- a/examples/contact.py
+++ b/examples/contact.py
@@ -60,9 +60,9 @@ def get_contacts(api_client: APIClient):
         all_contacts.extend(response.results)
         print(f"Fetched {len(response.results)} contacts (total: {len(all_contacts)})")
 
-        if not response.has_next or not response.next_cursor:
+        if not response.hasNext or not response.nextCursor:
             break
-        cursor = response.next_cursor
+        cursor = response.nextCursor
 
     print(f"Total contacts: {len(all_contacts)}")
     return all_contacts

--- a/examples/transactions.py
+++ b/examples/transactions.py
@@ -123,8 +123,8 @@ def get_transactions(api_client: APIClient):
             f"Fetched {len(response.results)} transactions (total: {len(all_transactions)})"
         )
 
-        if not response.has_next or not response.next_cursor:
+        if not response.hasNext or not response.nextCursor:
             break
-        cursor = response.next_cursor
+        cursor = response.nextCursor
 
     print(f"Total transactions: {len(all_transactions)}")

--- a/examples/transactions.py
+++ b/examples/transactions.py
@@ -5,7 +5,6 @@ from primevault_python_sdk.api_client import APIClient
 from primevault_python_sdk.base_api_client import (
     BadRequestError,
     InternalServerError,
-    NotFoundError,
     UnauthorizedError,
 )
 from primevault_python_sdk.types import (
@@ -101,48 +100,28 @@ def create_transfer_transaction(api_client: APIClient):
 
 def get_transactions(api_client: APIClient):
     """
-    Page-based pagination example.
+    Cursor-based pagination example.
     For date range filters, use createdAtGte and createdAtLte.
     """
-    limit = 50
-    page = 1
-    transactions = []
-    while True:
-        try:
-            dt = datetime.datetime.now() - datetime.timedelta(days=10)  # last 10 days
-            response = api_client.get_transactions(
-                params={
-                    "vaultId": "7ad54443-21d2-4075-abef-83758c9dceb7",
-                    "createdAtGte": str(dt),
-                    "status": TransactionStatus.COMPLETED.value,
-                },
-                page=page,
-                limit=limit,
-            )
-            transactions.append(response.results)
-        except NotFoundError:  # end of results
-            break
-        page += 1
-
-    print(transactions)
-
-
-def get_transactions_cursor(api_client: APIClient):
     limit = 50
     cursor = ""
     all_transactions = []
 
     while True:
+        dt = datetime.datetime.now() - datetime.timedelta(days=10)  # last 10 days
         response = api_client.get_transactions(
             params={
                 "vaultId": "7ad54443-21d2-4075-abef-83758c9dceb7",
+                "createdAtGte": str(dt),
                 "status": TransactionStatus.COMPLETED.value,
             },
             limit=limit,
             cursor=cursor,
         )
         all_transactions.extend(response.results)
-        print(f"Fetched {len(response.results)} transactions (total: {len(all_transactions)})")
+        print(
+            f"Fetched {len(response.results)} transactions (total: {len(all_transactions)})"
+        )
 
         if not response.has_next or not response.next_cursor:
             break

--- a/examples/vault.py
+++ b/examples/vault.py
@@ -21,3 +21,28 @@ def get_vault_balance(api_client: APIClient):
     vault_id = ""  # Vault ID
     balances: BalanceResponse = api_client.get_balances(vault_id)
     print(balances)
+
+
+def get_vaults(api_client: APIClient):
+    """List all vaults with cursor-based pagination."""
+    all_vaults = []
+    cursor = None
+
+    while True:
+        response = api_client.get_vaults(limit=50, cursor=cursor)
+        all_vaults.extend(response.results)
+        print(f"Fetched {len(response.results)} vaults (total: {len(all_vaults)})")
+
+        if not response.has_next or not response.next_cursor:
+            break
+        cursor = response.next_cursor
+
+    print(f"Total vaults: {len(all_vaults)}")
+    return all_vaults
+
+
+def get_vaults_filtered(api_client: APIClient):
+    """List vaults with a filter."""
+    response = api_client.get_vaults(params={"vaultName": "core-vault-1"}, limit=10)
+    for vault in response.results:
+        print(f"  {vault.id} — {vault.vaultName} ({vault.vaultType})")

--- a/examples/vault.py
+++ b/examples/vault.py
@@ -33,9 +33,9 @@ def get_vaults(api_client: APIClient):
         all_vaults.extend(response.results)
         print(f"Fetched {len(response.results)} vaults (total: {len(all_vaults)})")
 
-        if not response.has_next or not response.next_cursor:
+        if not response.hasNext or not response.nextCursor:
             break
-        cursor = response.next_cursor
+        cursor = response.nextCursor
 
     print(f"Total vaults: {len(all_vaults)}")
     return all_vaults

--- a/primevault_python_sdk/api_client.py
+++ b/primevault_python_sdk/api_client.py
@@ -56,14 +56,10 @@ class APIClient(BaseAPIClient):
     def get_transactions(
         self,
         params: Optional[dict] = None,
-        page: Optional[int] = 1,
         limit: Optional[int] = 20,
-        cursor: Optional[str] = None,
+        cursor: Optional[str] = "",
     ) -> TransactionListResponse:
-        if cursor is not None:
-            query = f"limit={limit}&cursor={cursor}"
-        else:
-            query = f"page={page}&limit={limit}"
+        query = f"limit={limit}&cursor={cursor or ''}"
         if params:
             query += "&" + "&".join([f"{k}={v}" for k, v in params.items()])
 
@@ -285,18 +281,17 @@ class APIClient(BaseAPIClient):
     def get_vaults(
         self,
         params: Optional[dict] = None,
-        page: Optional[int] = 1,
         limit: Optional[int] = 20,
-        reverse: Optional[bool] = False,
+        cursor: Optional[str] = "",
     ) -> VaultListResponse:
-        query_params = ""
+        query = f"limit={limit}&cursor={cursor or ''}"
         if params:
-            query_params = "&".join([f"{k}={v}" for k, v in params.items()])
+            query += "&" + "&".join([f"{k}={v}" for k, v in params.items()])
 
-        response = self.get(
-            f"/api/external/vaults/?limit={limit}&page={page}&reverse={reverse}&{query_params}"
+        return from_dict(
+            data_class=VaultListResponse,
+            data=self.get(f"/api/external/vaults/?{query}"),
         )
-        return from_dict(data_class=VaultListResponse, data=response)
 
     def get_vault_by_id(self, vault_id: str) -> Vault:
         return from_dict(Vault, self.get(f"/api/external/vaults/{vault_id}/"))
@@ -352,17 +347,17 @@ class APIClient(BaseAPIClient):
     def get_contacts(
         self,
         params: Optional[dict] = None,
-        page: Optional[int] = 1,
         limit: Optional[int] = 20,
+        cursor: Optional[str] = "",
     ) -> ContactListResponse:
-        query_params = ""
+        query = f"limit={limit}&cursor={cursor or ''}"
         if params:
-            query_params = "&".join([f"{k}={v}" for k, v in params.items()])
+            query += "&" + "&".join([f"{k}={v}" for k, v in params.items()])
 
-        response = self.get(
-            f"/api/external/contacts/?limit={limit}&page={page}&{query_params}"
+        return from_dict(
+            data_class=ContactListResponse,
+            data=self.get(f"/api/external/contacts/?{query}"),
         )
-        return from_dict(data_class=ContactListResponse, data=response)
 
     def get_contact_by_id(self, contact_id: str) -> Contact:
         return from_dict(Contact, self.get(f"/api/external/contacts/{contact_id}/"))
@@ -393,25 +388,23 @@ class APIClient(BaseAPIClient):
     def get_bank_accounts(
         self,
         params: Optional[dict] = None,
-        page: Optional[int] = 1,
         limit: Optional[int] = 20,
+        cursor: Optional[str] = "",
     ) -> BankAccountListResponse:
-        query_params = ""
+        query = f"limit={limit}&cursor={cursor or ''}"
         if params:
-            query_params = "&".join([f"{k}={v}" for k, v in params.items()])
+            query += "&" + "&".join([f"{k}={v}" for k, v in params.items()])
 
-        response = self.get(
-            f"/api/external/bank_accounts/?limit={limit}&page={page}&{query_params}"
+        response = self.get(f"/api/external/bank_accounts/?{query}")
+        return from_dict(
+            BankAccountListResponse, response, config=self._BANK_DACITE_CFG
         )
-        return from_dict(BankAccountListResponse, response, config=self._BANK_DACITE_CFG)
 
     def get_bank_account_by_id(self, bank_account_id: str) -> BankAccount:
         response = self.get(f"/api/external/bank_accounts/{bank_account_id}/")
         return from_dict(BankAccount, response, config=self._BANK_DACITE_CFG)
 
-    def create_bank_account(
-        self, request: CreateBankAccountRequest
-    ) -> BankAccount:
+    def create_bank_account(self, request: CreateBankAccountRequest) -> BankAccount:
         response = self.post("/api/external/bank_accounts/", data=asdict(request))
         return from_dict(BankAccount, response, config=self._BANK_DACITE_CFG)
 

--- a/primevault_python_sdk/api_client.py
+++ b/primevault_python_sdk/api_client.py
@@ -56,7 +56,6 @@ class APIClient(BaseAPIClient):
     def get_transactions(
         self,
         params: Optional[dict] = None,
-        page: Optional[int] = 1,
         limit: Optional[int] = 20,
         cursor: Optional[str] = None,
     ) -> TransactionListResponse:
@@ -64,10 +63,7 @@ class APIClient(BaseAPIClient):
         if params:
             query_params = "&".join([f"{k}={v}" for k, v in params.items()])
 
-        if cursor is not None:
-            url = f"/api/external/transactions/?limit={limit}&cursor={cursor}"
-        else:
-            url = f"/api/external/transactions/?page={page}&limit={limit}"
+        url = f"/api/external/transactions/?limit={limit}&cursor={cursor or ''}"
 
         if query_params:
             url += f"&{query_params}"
@@ -289,19 +285,14 @@ class APIClient(BaseAPIClient):
     def get_vaults(
         self,
         params: Optional[dict] = None,
-        page: Optional[int] = 1,
         limit: Optional[int] = 20,
-        reverse: Optional[bool] = False,
         cursor: Optional[str] = None,
     ) -> VaultListResponse:
         query_params = ""
         if params:
             query_params = "&".join([f"{k}={v}" for k, v in params.items()])
 
-        if cursor is not None:
-            url = f"/api/external/vaults/?limit={limit}&cursor={cursor}"
-        else:
-            url = f"/api/external/vaults/?limit={limit}&page={page}&reverse={reverse}"
+        url = f"/api/external/vaults/?limit={limit}&cursor={cursor or ''}"
 
         if query_params:
             url += f"&{query_params}"
@@ -362,7 +353,6 @@ class APIClient(BaseAPIClient):
     def get_contacts(
         self,
         params: Optional[dict] = None,
-        page: Optional[int] = 1,
         limit: Optional[int] = 20,
         cursor: Optional[str] = None,
     ) -> ContactListResponse:
@@ -370,10 +360,7 @@ class APIClient(BaseAPIClient):
         if params:
             query_params = "&".join([f"{k}={v}" for k, v in params.items()])
 
-        if cursor is not None:
-            url = f"/api/external/contacts/?limit={limit}&cursor={cursor}"
-        else:
-            url = f"/api/external/contacts/?limit={limit}&page={page}"
+        url = f"/api/external/contacts/?limit={limit}&cursor={cursor or ''}"
 
         if query_params:
             url += f"&{query_params}"
@@ -409,7 +396,6 @@ class APIClient(BaseAPIClient):
     def get_bank_accounts(
         self,
         params: Optional[dict] = None,
-        page: Optional[int] = 1,
         limit: Optional[int] = 20,
         cursor: Optional[str] = None,
     ) -> BankAccountListResponse:
@@ -417,10 +403,7 @@ class APIClient(BaseAPIClient):
         if params:
             query_params = "&".join([f"{k}={v}" for k, v in params.items()])
 
-        if cursor is not None:
-            url = f"/api/external/bank_accounts/?limit={limit}&cursor={cursor}"
-        else:
-            url = f"/api/external/bank_accounts/?limit={limit}&page={page}"
+        url = f"/api/external/bank_accounts/?limit={limit}&cursor={cursor or ''}"
 
         if query_params:
             url += f"&{query_params}"
@@ -433,9 +416,7 @@ class APIClient(BaseAPIClient):
         response = self.get(f"/api/external/bank_accounts/{bank_account_id}/")
         return from_dict(BankAccount, response, config=self._BANK_DACITE_CFG)
 
-    def create_bank_account(
-        self, request: CreateBankAccountRequest
-    ) -> BankAccount:
+    def create_bank_account(self, request: CreateBankAccountRequest) -> BankAccount:
         response = self.post("/api/external/bank_accounts/", data=asdict(request))
         return from_dict(BankAccount, response, config=self._BANK_DACITE_CFG)
 

--- a/primevault_python_sdk/api_client.py
+++ b/primevault_python_sdk/api_client.py
@@ -246,7 +246,6 @@ class APIClient(BaseAPIClient):
             "toAsset": request.toAsset,
             "toChain": request.toChain,
             "category": request.category,
-            "paymentMethod": request.paymentMethod,
         }
         return from_dict(
             RampQuoteResponse,

--- a/primevault_python_sdk/api_client.py
+++ b/primevault_python_sdk/api_client.py
@@ -56,17 +56,25 @@ class APIClient(BaseAPIClient):
     def get_transactions(
         self,
         params: Optional[dict] = None,
+        page: Optional[int] = 1,
         limit: Optional[int] = 20,
-        cursor: Optional[str] = "",
+        cursor: Optional[str] = None,
     ) -> TransactionListResponse:
-        query = f"limit={limit}&cursor={cursor or ''}"
+        query_params = ""
         if params:
-            query += "&" + "&".join([f"{k}={v}" for k, v in params.items()])
+            query_params = "&".join([f"{k}={v}" for k, v in params.items()])
+
+        if cursor is not None:
+            url = f"/api/external/transactions/?limit={limit}&cursor={cursor}"
+        else:
+            url = f"/api/external/transactions/?page={page}&limit={limit}"
+
+        if query_params:
+            url += f"&{query_params}"
 
         return from_dict(
             TransactionListResponse,
-            self.get(f"/api/external/transactions/?{query}"),
-            config=Config(cast=[str, int, float]),
+            self.get(url),
         )
 
     def get_transaction_by_id(self, transaction_id: str) -> Transaction:
@@ -281,17 +289,24 @@ class APIClient(BaseAPIClient):
     def get_vaults(
         self,
         params: Optional[dict] = None,
+        page: Optional[int] = 1,
         limit: Optional[int] = 20,
-        cursor: Optional[str] = "",
+        reverse: Optional[bool] = False,
+        cursor: Optional[str] = None,
     ) -> VaultListResponse:
-        query = f"limit={limit}&cursor={cursor or ''}"
+        query_params = ""
         if params:
-            query += "&" + "&".join([f"{k}={v}" for k, v in params.items()])
+            query_params = "&".join([f"{k}={v}" for k, v in params.items()])
 
-        return from_dict(
-            data_class=VaultListResponse,
-            data=self.get(f"/api/external/vaults/?{query}"),
-        )
+        if cursor is not None:
+            url = f"/api/external/vaults/?limit={limit}&cursor={cursor}"
+        else:
+            url = f"/api/external/vaults/?limit={limit}&page={page}&reverse={reverse}"
+
+        if query_params:
+            url += f"&{query_params}"
+
+        return from_dict(data_class=VaultListResponse, data=self.get(url))
 
     def get_vault_by_id(self, vault_id: str) -> Vault:
         return from_dict(Vault, self.get(f"/api/external/vaults/{vault_id}/"))
@@ -347,17 +362,23 @@ class APIClient(BaseAPIClient):
     def get_contacts(
         self,
         params: Optional[dict] = None,
+        page: Optional[int] = 1,
         limit: Optional[int] = 20,
-        cursor: Optional[str] = "",
+        cursor: Optional[str] = None,
     ) -> ContactListResponse:
-        query = f"limit={limit}&cursor={cursor or ''}"
+        query_params = ""
         if params:
-            query += "&" + "&".join([f"{k}={v}" for k, v in params.items()])
+            query_params = "&".join([f"{k}={v}" for k, v in params.items()])
 
-        return from_dict(
-            data_class=ContactListResponse,
-            data=self.get(f"/api/external/contacts/?{query}"),
-        )
+        if cursor is not None:
+            url = f"/api/external/contacts/?limit={limit}&cursor={cursor}"
+        else:
+            url = f"/api/external/contacts/?limit={limit}&page={page}"
+
+        if query_params:
+            url += f"&{query_params}"
+
+        return from_dict(data_class=ContactListResponse, data=self.get(url))
 
     def get_contact_by_id(self, contact_id: str) -> Contact:
         return from_dict(Contact, self.get(f"/api/external/contacts/{contact_id}/"))
@@ -388,23 +409,33 @@ class APIClient(BaseAPIClient):
     def get_bank_accounts(
         self,
         params: Optional[dict] = None,
+        page: Optional[int] = 1,
         limit: Optional[int] = 20,
-        cursor: Optional[str] = "",
+        cursor: Optional[str] = None,
     ) -> BankAccountListResponse:
-        query = f"limit={limit}&cursor={cursor or ''}"
+        query_params = ""
         if params:
-            query += "&" + "&".join([f"{k}={v}" for k, v in params.items()])
+            query_params = "&".join([f"{k}={v}" for k, v in params.items()])
 
-        response = self.get(f"/api/external/bank_accounts/?{query}")
+        if cursor is not None:
+            url = f"/api/external/bank_accounts/?limit={limit}&cursor={cursor}"
+        else:
+            url = f"/api/external/bank_accounts/?limit={limit}&page={page}"
+
+        if query_params:
+            url += f"&{query_params}"
+
         return from_dict(
-            BankAccountListResponse, response, config=self._BANK_DACITE_CFG
+            BankAccountListResponse, self.get(url), config=self._BANK_DACITE_CFG
         )
 
     def get_bank_account_by_id(self, bank_account_id: str) -> BankAccount:
         response = self.get(f"/api/external/bank_accounts/{bank_account_id}/")
         return from_dict(BankAccount, response, config=self._BANK_DACITE_CFG)
 
-    def create_bank_account(self, request: CreateBankAccountRequest) -> BankAccount:
+    def create_bank_account(
+        self, request: CreateBankAccountRequest
+    ) -> BankAccount:
         response = self.post("/api/external/bank_accounts/", data=asdict(request))
         return from_dict(BankAccount, response, config=self._BANK_DACITE_CFG)
 

--- a/primevault_python_sdk/types.py
+++ b/primevault_python_sdk/types.py
@@ -206,7 +206,7 @@ TransactionOutput = Union[EVMOutput, ICPOutput]
 
 
 @dataclass
-class TransactionBankDetails:
+class BankDetails:  # type: ignore[no-redef]
     bankName: Optional[str] = None
     beneficiaryName: Optional[str] = None
     accountNumberMasked: Optional[str] = None
@@ -226,7 +226,7 @@ class TransactionSourceData:
     name: Optional[str] = None
     address: Optional[str] = None
     exchange: Optional[str] = None
-    bank: Optional[TransactionBankDetails] = None
+    bank: Optional[BankDetails] = None
 
 
 @dataclass

--- a/primevault_python_sdk/types.py
+++ b/primevault_python_sdk/types.py
@@ -117,12 +117,10 @@ class BankDetails:
     beneficiaryName: Optional[str] = None
     accountName: Optional[str] = None
     accountNumber: Optional[str] = None
-    accountNumberMasked: Optional[str] = None
     routingNumber: Optional[str] = None
     paymentRail: Optional[str] = None
     bankAddress: Optional[str] = None
     swiftCode: Optional[str] = None
-    swiftBic: Optional[str] = None
     iban: Optional[str] = None
     currency: Optional[str] = None
     country: Optional[str] = None

--- a/primevault_python_sdk/types.py
+++ b/primevault_python_sdk/types.py
@@ -255,7 +255,6 @@ class RampQuoteRequest:
     toAsset: Optional[str] = None
     toChain: Optional[str] = None
     category: Optional[str] = None
-    paymentMethod: Optional[str] = None
 
 
 @dataclass

--- a/primevault_python_sdk/types.py
+++ b/primevault_python_sdk/types.py
@@ -117,10 +117,12 @@ class BankDetails:
     beneficiaryName: Optional[str] = None
     accountName: Optional[str] = None
     accountNumber: Optional[str] = None
+    accountNumberMasked: Optional[str] = None
     routingNumber: Optional[str] = None
     paymentRail: Optional[str] = None
     bankAddress: Optional[str] = None
     swiftCode: Optional[str] = None
+    swiftBic: Optional[str] = None
     iban: Optional[str] = None
     currency: Optional[str] = None
     country: Optional[str] = None

--- a/primevault_python_sdk/types.py
+++ b/primevault_python_sdk/types.py
@@ -1,7 +1,6 @@
 import datetime
 from dataclasses import dataclass
 from enum import Enum
-from symtable import Class
 from typing import Any, Dict, List, Optional, Union
 
 
@@ -41,11 +40,11 @@ class TransactionCategory(str, Enum):
     SWAP = "SWAP"
     ON_RAMP = "ON_RAMP"
     OFF_RAMP = "OFF_RAMP"
-    TOKEN_TRANSFER = "TOKEN_TRANSFER"
-    TOKEN_APPROVAL = "TOKEN_APPROVAL"
+    TOKEN_TRANSFER = "TOKEN_TRANSFER"  # nosec B105
+    TOKEN_APPROVAL = "TOKEN_APPROVAL"  # nosec B105
     CONTRACT_CALL = "CONTRACT_CALL"
     STAKE = "STAKE"
-    REVOKE_TOKEN_ALLOWANCE = "REVOKE_TOKEN_ALLOWANCE"
+    REVOKE_TOKEN_ALLOWANCE = "REVOKE_TOKEN_ALLOWANCE"  # nosec B105
 
 
 class TransactionSubCategory(str, Enum):
@@ -207,7 +206,7 @@ TransactionOutput = Union[EVMOutput, ICPOutput]
 
 
 @dataclass
-class BankDetails:
+class TransactionBankDetails:
     bankName: Optional[str] = None
     beneficiaryName: Optional[str] = None
     accountNumberMasked: Optional[str] = None
@@ -227,7 +226,7 @@ class TransactionSourceData:
     name: Optional[str] = None
     address: Optional[str] = None
     exchange: Optional[str] = None
-    bank: Optional[BankDetails] = None
+    bank: Optional[TransactionBankDetails] = None
 
 
 @dataclass
@@ -256,6 +255,7 @@ class RampQuoteRequest:
     toAsset: Optional[str] = None
     toChain: Optional[str] = None
     category: Optional[str] = None
+    paymentMethod: Optional[str] = None
 
 
 @dataclass
@@ -572,17 +572,13 @@ class DepositAddressResponse:
 @dataclass
 class VaultListResponse:
     results: List[Vault]
-    count: int
-    previous: Optional[str] = None
-    next: Optional[str] = None
+    next_cursor: Optional[str] = None
+    has_next: Optional[bool] = None
 
 
 @dataclass
 class TransactionListResponse:
     results: List[Transaction]
-    count: Optional[int] = None
-    previous: Optional[str] = None
-    next: Optional[str] = None
     next_cursor: Optional[str] = None
     has_next: Optional[bool] = None
 
@@ -590,9 +586,8 @@ class TransactionListResponse:
 @dataclass
 class ContactListResponse:
     results: List[Contact]
-    count: int
-    previous: Optional[str] = None
-    next: Optional[str] = None
+    next_cursor: Optional[str] = None
+    has_next: Optional[bool] = None
 
 
 @dataclass
@@ -621,9 +616,8 @@ class BankAccount:
 @dataclass
 class BankAccountListResponse:
     results: List[BankAccount]
-    count: int
-    previous: Optional[str] = None
-    next: Optional[str] = None
+    next_cursor: Optional[str] = None
+    has_next: Optional[bool] = None
 
 
 @dataclass

--- a/primevault_python_sdk/types.py
+++ b/primevault_python_sdk/types.py
@@ -117,7 +117,6 @@ class BankDetails:
     beneficiaryName: Optional[str] = None
     accountName: Optional[str] = None
     accountNumber: Optional[str] = None
-    accountNumberMasked: Optional[str] = None
     routingNumber: Optional[str] = None
     paymentRail: Optional[str] = None
     bankAddress: Optional[str] = None

--- a/primevault_python_sdk/types.py
+++ b/primevault_python_sdk/types.py
@@ -117,10 +117,12 @@ class BankDetails:
     beneficiaryName: Optional[str] = None
     accountName: Optional[str] = None
     accountNumber: Optional[str] = None
+    accountNumberMasked: Optional[str] = None
     routingNumber: Optional[str] = None
     paymentRail: Optional[str] = None
     bankAddress: Optional[str] = None
     swiftCode: Optional[str] = None
+    swiftBic: Optional[str] = None
     iban: Optional[str] = None
     currency: Optional[str] = None
     country: Optional[str] = None
@@ -203,20 +205,6 @@ class ICPOutput:
 
 # A transaction output can be one of these two
 TransactionOutput = Union[EVMOutput, ICPOutput]
-
-
-@dataclass
-class BankDetails:  # type: ignore[no-redef]
-    bankName: Optional[str] = None
-    beneficiaryName: Optional[str] = None
-    accountNumberMasked: Optional[str] = None
-    iban: Optional[str] = None
-    swiftBic: Optional[str] = None
-    routingNumber: Optional[str] = None
-    paymentRail: Optional[str] = None
-    currency: Optional[str] = None
-    country: Optional[str] = None
-    bankAddress: Optional[str] = None
 
 
 @dataclass

--- a/primevault_python_sdk/types.py
+++ b/primevault_python_sdk/types.py
@@ -558,22 +558,22 @@ class DepositAddressResponse:
 @dataclass
 class VaultListResponse:
     results: List[Vault]
-    next_cursor: Optional[str] = None
-    has_next: Optional[bool] = None
+    nextCursor: Optional[str] = None
+    hasNext: Optional[bool] = None
 
 
 @dataclass
 class TransactionListResponse:
     results: List[Transaction]
-    next_cursor: Optional[str] = None
-    has_next: Optional[bool] = None
+    nextCursor: Optional[str] = None
+    hasNext: Optional[bool] = None
 
 
 @dataclass
 class ContactListResponse:
     results: List[Contact]
-    next_cursor: Optional[str] = None
-    has_next: Optional[bool] = None
+    nextCursor: Optional[str] = None
+    hasNext: Optional[bool] = None
 
 
 @dataclass
@@ -602,8 +602,8 @@ class BankAccount:
 @dataclass
 class BankAccountListResponse:
     results: List[BankAccount]
-    next_cursor: Optional[str] = None
-    has_next: Optional[bool] = None
+    nextCursor: Optional[str] = None
+    hasNext: Optional[bool] = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Removes page-based pagination support (count, previous, next) from all list response types
- Adds cursor-based fields: `hasNext`, `nextCursor`
- Updates all examples to use cursor-only pagination
- Consolidates `BankDetails` into a single generic dataclass

## Test plan
- [x] Deserialization tests passing against deployed backend
- [x] Old vs new ID consistency tests passing


Made with [Cursor](https://cursor.com)